### PR TITLE
add disabled functionality to side menu

### DIFF
--- a/addon/components/side-menu.js
+++ b/addon/components/side-menu.js
@@ -20,11 +20,13 @@ export default Component.extend({
     progress: alias("sideMenu.progress"),
     isOpen: alias("sideMenu.isOpen"),
     isClosed: alias("sideMenu.isClosed"),
+    isDisabled: alias("sideMenu.isDisabled"),
     isSlightlyOpen: alias("sideMenu.isSlightlyOpen"),
     isTouching: false,
 
     attributeBindings: ["style"],
     classNames: ["side-menu"],
+    classNameBindings: ["isDisabled:side-menu-disabled"],
 
     side: "left",
     width: "70%",

--- a/addon/services/side-menu.js
+++ b/addon/services/side-menu.js
@@ -1,7 +1,8 @@
 import Ember from "ember";
 
 const {
-    computed: { equal },
+    computed: { equal, reads, not },
+    computed,
     get,
     set,
     Service,
@@ -12,7 +13,18 @@ export default Service.extend({
     progress: 0,
     isOpen: equal("progress", 100),
     isClosed: equal("progress", 0),
+    isDisabled: reads("disabled"),
+    isEnabled: not("disabled"),
     isSlightlyOpen: false,
+    disabled: computed({
+        get() {
+            return false;
+        },
+        set(_key, value) {
+            if (value) { this.close(); }
+            return value;
+        },
+    }),
 
     close() {
         set(this, "progress", 0);
@@ -20,6 +32,7 @@ export default Service.extend({
     },
 
     open() {
+        if (get(this, "disabled")) { return; }
         set(this, "progress", 100);
         set(this, "isSlightlyOpen", false);
     },
@@ -30,5 +43,13 @@ export default Service.extend({
         } else {
             this.open();
         }
+    },
+
+    disable() {
+        set(this, "disabled", true);
+    },
+
+    enable() {
+        set(this, "disabled", false);
     },
 });

--- a/tests/integration/components/side-menu-toggle-test.js
+++ b/tests/integration/components/side-menu-toggle-test.js
@@ -43,3 +43,21 @@ test("click should toggle menu", function (assert) {
 
     assert.ok(this.get("sideMenu.isClosed"), "another click closing");
 });
+
+test("click should not toggle menu open when disabled", function (assert) {
+    assert.expect(3);
+
+    this.render(hbs`{{side-menu-toggle}}`);
+
+    assert.ok(this.get("sideMenu.isClosed"), "initially closed");
+
+    this.set("sideMenu.disabled", true);
+    this.$(".side-menu-toggle").click();
+
+    assert.ok(this.get("sideMenu.isClosed"), "after click is still closed");
+
+    this.set("sideMenu.disabled", false);
+    this.$(".side-menu-toggle").click();
+
+    assert.ok(this.get("sideMenu.isOpen"), "opens after enabling");
+});

--- a/tests/unit/services/side-menu-test.js
+++ b/tests/unit/services/side-menu-test.js
@@ -49,3 +49,43 @@ test("toggle should toggle menu", function (assert) {
 
     assert.ok(service.get("isClosed"));
 });
+
+test("disable should disable the menu", function (assert) {
+    assert.expect(4);
+
+    const service = this.subject();
+
+    service.open();
+
+    assert.ok(service.get("isOpen"));
+
+    service.disable();
+
+    assert.ok(service.get("isClosed"), "disabling automatically closes the side menu");
+    assert.ok(service.get("isDisabled"));
+
+    service.toggle();
+
+    assert.ok(service.get("isClosed"), "disabled side-menu will not open");
+});
+
+test("enable should enable the menu after being disabled", function (assert) {
+    assert.expect(5);
+
+    const service = this.subject();
+
+    service.open();
+
+    assert.ok(service.get("isOpen"));
+
+    service.disable();
+
+    assert.ok(service.get("isClosed"), "disabling automatically closes the side menu");
+    assert.ok(service.get("isDisabled"));
+
+    service.enable();
+    service.toggle();
+
+    assert.ok(service.get("isOpen"));
+    assert.ok(service.get("isEnabled"));
+});


### PR DESCRIPTION
## Disabled

This will add a "disabled" state to the side-menu. When the menu is disabled, the menu is closed and cannot be opened until enabled.
### Use case

Depending on what route we are in, we want to use an Ember Wormhole to render content into the side menu. However, this means that if you are outside of a route that renders into the side menu, it may be empty.

Opening it at that point via swipe then would reveal an empty side menu. This option prevents this.
