### PR TITLE
Allow to override progress property of backdrop-content

### DIFF
--- a/addon/components/content-backdrop.js
+++ b/addon/components/content-backdrop.js
@@ -4,7 +4,7 @@ const {
     Component,
     computed,
     String: { htmlSafe },
-    computed: { alias },
+    computed: { oneWay },
     inject: { service },
     get,
 } = Ember;
@@ -12,7 +12,7 @@ const {
 export default Component.extend({
     sideMenu: service(),
 
-    progress: alias("sideMenu.progress"),
+    progress: oneWay("sideMenu.progress"),
 
     attributeBindings: ["style"],
     classNames: ["content-backdrop"],


### PR DESCRIPTION
Hello,

In my project I want to use consistent backdrop animations. Beside ember-side-menu I use my own custom sidebar, and I want it to make similar backdrop when opened. Example of my code that will work only if progress is ``oneWay`` instead of ``alias``:
```handlebars
    {{content-backdrop class="sidenav-backdrop"
      progress=(if sidenavSidebarOpen 100 0)
      click=(action "closeSidenav" bubbles=true)
    }}
```

Where ``closeSidenav`` is my custom action to close my custom sidebar and ``sidenavSidebarOpen`` is boolean state of my custom sidebar.

This should not broke anything, because ``sideMenu.progress`` should not be modified using ``progress`` property anyway.

Best regards,
Jakub