### PR TITLE
Safely update menus in slide-menu service (glimmer compat)

### DIFF
--- a/addon/services/side-menu.js
+++ b/addon/services/side-menu.js
@@ -27,7 +27,7 @@ export default Service.extend({
   create(menuId = 'default') {
     const menus = get(this, 'menus');
     const newMenu = MenuObject.create({ id: menuId });
-    menus[menuId] = newMenu;
+    set(menus, menuId, newMenu);
     set(this, 'menus', Object.assign({}, menus));
 
     return newMenu;


### PR DESCRIPTION
When updating to Ember 3.28, I got the following error involving ember-side-menu:

```
index.js:181 Uncaught Error: Assertion Failed: You attempted to update [object Object].default to "<(unknown):ember545>", but it is being tracked by a tracking context, such as a template, computed property, or observer. In order to make sure the context updates properly, you must invalidate the property when updating it. You can mark the property as `@tracked`, or use `@ember/object#set` to do this.
    at assert (index.js:181)
    at Object.set [as default] (index.js:899)
    at Class.create (side-menu.js:35)
    at Class._initMenu (side-menu.js:109)
    at Class.didInsertElement (side-menu.js:95)
    at Class.superWrapper [as didInsertElement] (index.js:445)
    at Class.trigger (core_view.js:68)
    at Class.superWrapper [as trigger] (index.js:445)
    at CurlyComponentManager.didCreate (index.js:1178)
    at TransactionImpl.commit (runtime.js:4815)
```

Using `set` resolves the issue.